### PR TITLE
Work around various issues encountered in OOT/Majora's mask

### DIFF
--- a/dwarfone/dwarfone/DWARF.cs
+++ b/dwarfone/dwarfone/DWARF.cs
@@ -336,9 +336,11 @@ namespace dwarfone
                 case 8226: // Reference to (global) variable; Used in functions
                     return true;
                 default:
+                {
                     if(!silent)
                         Console.WriteLine($"Failed on at: {at}");
                     return false;
+                }
             }
         }
 
@@ -438,6 +440,7 @@ namespace dwarfone
                 case (int)Form.FORM_DATA4:
                 case (int)Form.FORM_DATA2:
                 case (int)Form.FORM_DATA8:
+                {
                     switch (at & 0xFFF0)
                     {
                         case (int)At.AT_language:
@@ -450,16 +453,19 @@ namespace dwarfone
                             text = ("        " + Enum.GetName(typeof(At), at & 0xFFF0) + "(0x" + value.ToString("x") + ")");
                             break;
                     }
-                    break;
+                } break;
                 case (int)Form.FORM_STRING:
+                {
                     text = ("        " + Enum.GetName(typeof(At), at & 0xFFF0) + "(\"" + str + "\")");
-                    break;
+                } break;
                 case (int)Form.FORM_BLOCK2:
                 case (int)Form.FORM_BLOCK4:
+                {
                     switch (at & 0xFFF0)
                     {
                         case (int)At.AT_return_addr:
                         case (int)At.AT_location:
+                        {
                             string loc = "";
                             for (uint i = 0; i < value; i++)
                             {
@@ -470,6 +476,7 @@ namespace dwarfone
                                     case (int)Op.OP_BASEREG:
                                     case (int)Op.OP_CONST:
                                     case (int)Op.OP_REG:
+                                    {
                                         uint reg = ELF.ReadUInt32(elf_data, elf.GetEndian());
                                         uint regLE = BinaryPrimitives.ReverseEndianness(reg);
 
@@ -478,19 +485,21 @@ namespace dwarfone
 
                                         loc += $"{Enum.GetName(typeof(Op), op)}(0x{reg.ToString("x")}) ";
                                         i += 4;
-                                        break;
+                                    } break;
                                     case (int)Op.OP_ADD:
                                     case (int)Op.OP_DEREF:
                                     case (int)Op.OP_DEREF2:
                                     case (int)Op.OP_hi_user:
                                     case (int)Op.OP_lo_user:
+                                    {
                                         loc += Enum.GetName(typeof(Op), op) + " ";
-                                        break;
+                                    } break;
                                 }
                             }
                             text = ("        " + Enum.GetName(typeof(At), at & 0xFFF0) + "(<" + value + ">" + loc + ")");
-                            break;
+                        } break;
                         case (int)At.AT_mod_fund_type:
+                        {
                             string mod_f = "";
                             for (uint i = 0; i < (value - 2); i++)
                             {
@@ -498,8 +507,9 @@ namespace dwarfone
                             }
                             mod_f += Enum.GetName(typeof(Ft), ELF.ReadUInt16(elf_data, elf.GetEndian()));
                             text = ("        " + Enum.GetName(typeof(At), at & 0xFFF0) + "(<" + value + ">" + mod_f + ")");
-                            break;
+                        } break;
                         case (int)At.AT_mod_u_d_type:
+                        {
                             string mod = "";
                             for (uint i = 0; i < (value - 4); i++)
                             {
@@ -507,8 +517,9 @@ namespace dwarfone
                             }
                             mod += "0x" + ELF.ReadUInt32(elf_data, elf.GetEndian()).ToString("x");
                             text = ("        " + Enum.GetName(typeof(At), at & 0xFFF0) + "(<" + value + ">" + mod + ")");
-                            break;
+                        } break;
                         case (int)At.AT_element_list:
+                        {
                             string list = "";
                             long start_pos_list = elf_data.Position;
                             while (elf_data.Position < (start_pos_list + (long)value))
@@ -516,8 +527,9 @@ namespace dwarfone
                                 list += "(" + ELF.ReadUInt32(elf_data, elf.GetEndian()).ToString() + "=\"" + ELF.ReadString(elf_data) + "\")";
                             }
                             text = ("        " + Enum.GetName(typeof(At), at & 0xFFF0) + "(<" + value + ">" + list + ")");
-                            break;
+                        } break;
                         case (int)At.AT_subscr_data:
+                        {
                             long start_pos_sub = elf_data.Position;
                             string fmt_str = "";
                             while (elf_data.Position < (start_pos_sub + (long)value))
@@ -527,34 +539,37 @@ namespace dwarfone
                                 switch (fmt)
                                 {
                                     case (int)Fmt.FMT_ET:
+                                    {
                                         GetAT(elf, elf_data, out fmt_str_out, enableQuirks);
                                         fmt_str += "FMT_ET: " + fmt_str_out.Substring(8) + ", ";
-                                        break;
+                                    } break;
                                     case (int)Fmt.FMT_FT_C_C:
+                                    {
                                         ushort fmt_ft = ELF.ReadUInt16(elf_data, elf.GetEndian());
                                         uint lo = ELF.ReadUInt32(elf_data, elf.GetEndian());
                                         uint hi = ELF.ReadUInt32(elf_data, elf.GetEndian());
                                         fmt_str += Enum.GetName(typeof(Ft), fmt_ft) + "[" + lo + ":" + hi + "], ";
-                                        break;
+                                    } break;
                                     default:
                                         elf_data.ReadByte();
-                                        break;
+                                    break;
                                 }
                             }
                             text = ("        " + Enum.GetName(typeof(At), at & 0xFFF0) + "(<" + value + ">" + fmt_str.Substring(0, fmt_str.Length - 2) + ")");
-                            break;
+                        } break;
                         case (int)At.AT_discr_value:
                         case (int)At.AT_string_length:
                         case (int)At.AT_const_value:
                         case (int)At.AT_friends:
                         case (int)At.AT_codewarrior_custom:
                         default:
+                        {
                             for (uint i = 0; i < value; i++)
                                 elf_data.ReadByte();
                             text = ("        " + Enum.GetName(typeof(At), at & 0xFFF0) + "(<" + value + "> TODO" + ")");
-                            break;
+                        } break;
                     }
-                    break;
+                } break;
             }
             return 0;
         }

--- a/dwarfone/dwarfone/DWARF.cs
+++ b/dwarfone/dwarfone/DWARF.cs
@@ -501,11 +501,35 @@ namespace dwarfone
                         case (int)At.AT_mod_fund_type:
                         {
                             string mod_f = "";
+
+                            // It sometimes happens in SIM.elf (OOT/Majora) that
+                            // the mod byte and the type are switched. It only
+                            // happens when value == 3, so I don't know if a
+                            // more sophisticated check is needed or if this
+                            // suffices...
+                            bool typeOverride = false;
+                            ushort type = 0;
+
                             for (uint i = 0; i < (value - 2); i++)
                             {
-                                mod_f += Enum.GetName(typeof(Mod), elf_data.ReadByte()) + " ";
+                                int mod = elf_data.ReadByte();
+
+                                if(!Enum.IsDefined(typeof(Mod), mod))
+                                {
+                                    typeOverride = true;
+                                    type = (ushort)(mod << 8);
+                                    mod = elf_data.ReadByte();
+                                }
+
+                                mod_f += Enum.GetName(typeof(Mod), mod) + " ";
                             }
-                            mod_f += Enum.GetName(typeof(Ft), ELF.ReadUInt16(elf_data, elf.GetEndian()));
+
+                            if(typeOverride)
+                                type |= (ushort)elf_data.ReadByte();
+                            else
+                                type = ELF.ReadUInt16(elf_data, elf.GetEndian());
+
+                            mod_f += Enum.GetName(typeof(Ft), type);
                             text = ("        " + Enum.GetName(typeof(At), at & 0xFFF0) + "(<" + value + ">" + mod_f + ")");
                         } break;
                         case (int)At.AT_mod_u_d_type:

--- a/dwarfone/dwarfone/DWARF.cs
+++ b/dwarfone/dwarfone/DWARF.cs
@@ -199,7 +199,7 @@ namespace dwarfone
             FMT_ET = 0x8
         }
 
-        public static void DumpDWARF(ELF elf)
+        public static void DumpDWARF(ELF elf, bool enableQuirks)
         {
             Console.WriteLine("DWARF v1 dump ---------------\n");
             Console.WriteLine(".debug File Offset: 0x" + elf.debug_offset.ToString("x"));
@@ -236,7 +236,7 @@ namespace dwarfone
                     {
                         string text = "";
 
-                        int result = GetAT(elf, elf_data, out text);
+                        int result = GetAT(elf, elf_data, out text, enableQuirks);
                         if (result > 0)
                         {
                             sizeIsLE = result == 2;
@@ -342,7 +342,7 @@ namespace dwarfone
             }
         }
 
-        public static int GetAT(ELF elf, MemoryStream elf_data, out string text)
+        public static int GetAT(ELF elf, MemoryStream elf_data, out string text, bool enableQuirks)
         {
             ushort at = ELF.ReadUInt16(elf_data, elf.GetEndian());
             ulong value = 0;
@@ -473,7 +473,8 @@ namespace dwarfone
                                         uint reg = ELF.ReadUInt32(elf_data, elf.GetEndian());
                                         uint regLE = BinaryPrimitives.ReverseEndianness(reg);
 
-                                        reg = Math.Min(reg, regLE);
+                                        if(enableQuirks)
+                                            reg = Math.Min(reg, regLE);
 
                                         loc += $"{Enum.GetName(typeof(Op), op)}(0x{reg.ToString("x")}) ";
                                         i += 4;
@@ -526,7 +527,7 @@ namespace dwarfone
                                 switch (fmt)
                                 {
                                     case (int)Fmt.FMT_ET:
-                                        GetAT(elf, elf_data, out fmt_str_out);
+                                        GetAT(elf, elf_data, out fmt_str_out, enableQuirks);
                                         fmt_str += "FMT_ET: " + fmt_str_out.Substring(8) + ", ";
                                         break;
                                     case (int)Fmt.FMT_FT_C_C:

--- a/dwarfone/dwarfone/Program.cs
+++ b/dwarfone/dwarfone/Program.cs
@@ -14,17 +14,20 @@ namespace dwarfone
 
             if (args.Length == 0)
             {
-                Console.WriteLine("Usage: dwarfone <elf file>");
+                Console.WriteLine("Usage: dwarfone [--enable-quirks] <elf file>");
             }
             else
             {
-                ELF elf = new ELF(args[0]);
+                bool quirksEnabled = args[0] == "--enable-quirks";
+                string name = quirksEnabled ? args[1] : args[0];
+
+                ELF elf = new ELF(name);
                 if (elf.GetError() != 0)
                     Console.WriteLine("Error Code: " + elf.GetError());
                 else
                     Console.WriteLine("ELF file successfully loaded");
 
-                DWARF.DumpDWARF(elf);
+                DWARF.DumpDWARF(elf, quirksEnabled);
             }
         }
     }

--- a/dwarfone/dwarfone/dwarfone.csproj
+++ b/dwarfone/dwarfone/dwarfone.csproj
@@ -1,55 +1,10 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-  <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{8665A77F-9EB2-4B02-A050-E9D5C7C37796}</ProjectGuid>
-    <OutputType>Exe</OutputType>
-    <RootNamespace>dwarfone</RootNamespace>
-    <AssemblyName>dwarfone</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <Deterministic>true</Deterministic>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml" />
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="DWARF.cs" />
-    <Compile Include="ELF.cs" />
-    <Compile Include="Program.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="App.config" />
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
+		<TargetFramework>net6.0</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+		<UseAppHost>true</UseAppHost>
+	</PropertyGroup>
 </Project>


### PR DESCRIPTION
Apparently endianness is just a suggestion to the compiler writers. Either way, both OOT's SIM.elf and Majora's SIM.elf can now be dumped without any glaring issues.